### PR TITLE
Clean up confguration access

### DIFF
--- a/dcompose.go
+++ b/dcompose.go
@@ -56,14 +56,68 @@ var (
 	hostworkingdir string
 )
 
+// JobComposition is the top-level type for what will become a job's docker-compose
+// file.
+type JobComposition struct {
+	Version  string `yaml:"version"`
+	Volumes  map[string]*Volume
+	Networks map[string]*Network `yaml:",omitempty"`
+	Services map[string]*Service
+}
+
+// NewJobComposition returns a newly instantiated *JobComposition instance.
+func NewJobComposition(ld string, pathprefix string) (*JobComposition, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get host working directory")
+	}
+
+	logdriver = ld
+	hostworkingdir = strings.TrimPrefix(wd, pathprefix)
+	if strings.HasPrefix(hostworkingdir, "/") {
+		hostworkingdir = strings.TrimPrefix(hostworkingdir, "/")
+	}
+
+	return &JobComposition{
+		Version:  "2.2",
+		Volumes:  make(map[string]*Volume),
+		Networks: make(map[string]*Network),
+		Services: make(map[string]*Service),
+	}, nil
+}
+
+// Composer orchestrates the creation of the docker-compose file for a job.
+type Composer struct {
+	job         *model.Job
+	cfg         *viper.Viper
+	composition *JobComposition
+	ingressID   string // This shouldn't be accessed directly. Use IngressID().
+}
+
+// NewComposer returns a new *Composer.
+func NewComposer(job *model.Job, cfg *viper.Viper, logDriver, pathPrefix string) (*Composer, error) {
+	c, err := NewJobComposition(logDriver, pathPrefix)
+	if err != nil {
+		return nil, err
+	}
+	return &Composer{
+		job:         job,
+		cfg:         cfg,
+		composition: c,
+	}, nil
+}
+
 // IngressID returns the name/identifier for the ingress in k8s.
-func IngressID(invocationID, userID string) string {
-	return fmt.Sprintf("a%x", sha256.Sum256([]byte(fmt.Sprintf("%s%s", userID, invocationID))))[0:9]
+func (c *Composer) IngressID() string {
+	if c.ingressID == "" {
+		c.ingressID = fmt.Sprintf("a%x", sha256.Sum256([]byte(fmt.Sprintf("%s%s", c.job.UserID, c.job.InvocationID))))[0:9]
+	}
+	return c.ingressID
 }
 
 // FrontendURL generates the full URL to to the running app, as shown to the
 // user and accessed through a browser.
-func FrontendURL(invID, ingressID string, step *model.Step, cfg *viper.Viper) (string, error) {
+func (c *Composer) FrontendURL(step *model.Step) (string, error) {
 	var (
 		unmodifiedURL string
 		fURL          *url.URL
@@ -73,7 +127,7 @@ func FrontendURL(invID, ingressID string, step *model.Step, cfg *viper.Viper) (s
 	if step.Component.Container.InteractiveApps.FrontendURL != "" {
 		unmodifiedURL = step.Component.Container.InteractiveApps.FrontendURL
 	} else {
-		unmodifiedURL = cfg.GetString(ConfigFrontendBaseKey)
+		unmodifiedURL = c.cfg.GetString(ConfigFrontendBaseKey)
 	}
 
 	fURL, err = url.Parse(unmodifiedURL)
@@ -82,7 +136,7 @@ func FrontendURL(invID, ingressID string, step *model.Step, cfg *viper.Viper) (s
 	}
 
 	fURLPort := fURL.Port()
-	fURLHost := fmt.Sprintf("%s.%s", ingressID, fURL.Hostname())
+	fURLHost := fmt.Sprintf("%s.%s", c.IngressID(), fURL.Hostname())
 
 	if fURLPort != "" {
 		fURL.Host = fmt.Sprintf("%s:%s", fURLHost, fURLPort)
@@ -151,51 +205,21 @@ type Service struct {
 	WorkingDir    string                           `yaml:"working_dir,omitempty"`
 }
 
-// JobCompose is the top-level type for what will become a job's docker-compose
-// file.
-type JobCompose struct {
-	Version  string `yaml:"version"`
-	Volumes  map[string]*Volume
-	Networks map[string]*Network `yaml:",omitempty"`
-	Services map[string]*Service
-}
-
-// New returns a newly instantiated *JobCompose instance.
-func New(ld string, pathprefix string) (*JobCompose, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get host working directory")
-	}
-
-	logdriver = ld
-	hostworkingdir = strings.TrimPrefix(wd, pathprefix)
-	if strings.HasPrefix(hostworkingdir, "/") {
-		hostworkingdir = strings.TrimPrefix(hostworkingdir, "/")
-	}
-
-	return &JobCompose{
-		Version:  "2.2",
-		Volumes:  make(map[string]*Volume),
-		Networks: make(map[string]*Network),
-		Services: make(map[string]*Service),
-	}, nil
-}
-
 // InitFromJob fills out values as appropriate for running in the DE's Condor
 // Cluster.
-func (j *JobCompose) InitFromJob(job *model.Job, cfg *viper.Viper, workingdir string, availablePort int) error {
+func (c *Composer) InitFromJob(workingdir string, availablePort int) error {
 	var err error
 
 	workingVolumeHostPath := path.Join(workingdir, VOLUMEDIR)
 	// The volume containing the local working directory
 
-	porklockImage := cfg.GetString(ConfigPorklockImageKey)
-	porklockTag := cfg.GetString(ConfigPorklockTagKey)
+	porklockImage := c.cfg.GetString(ConfigPorklockImageKey)
+	porklockTag := c.cfg.GetString(ConfigPorklockTagKey)
 	porklockImageName := fmt.Sprintf("%s:%s", porklockImage, porklockTag)
 
 	for index, dc := range job.DataContainers() {
 		svcKey := fmt.Sprintf("data_%d", index)
-		j.Services[svcKey] = &Service{
+		c.composition.Services[svcKey] = &Service{
 			Image:         fmt.Sprintf("%s:%s", dc.Name, dc.Tag),
 			ContainerName: fmt.Sprintf("%s-%s", dc.NamePrefix, job.InvocationID),
 			EntryPoint:    "/bin/true",
@@ -205,7 +229,7 @@ func (j *JobCompose) InitFromJob(job *model.Job, cfg *viper.Viper, workingdir st
 			},
 		}
 
-		svc := j.Services[svcKey]
+		svc := c.composition.Services[svcKey]
 		if dc.HostPath != "" || dc.ContainerPath != "" {
 			var rw string
 			if dc.ReadOnly {
@@ -220,7 +244,7 @@ func (j *JobCompose) InitFromJob(job *model.Job, cfg *viper.Viper, workingdir st
 	}
 
 	for index, input := range job.Inputs() {
-		j.Services[fmt.Sprintf("input_%d", index)] = &Service{
+		c.composition.Services[fmt.Sprintf("input_%d", index)] = &Service{
 			CapAdd:  []string{"IPC_LOCK"},
 			Image:   porklockImageName,
 			Command: input.Arguments(job.Submitter, job.FileMetadata),
@@ -243,7 +267,7 @@ func (j *JobCompose) InitFromJob(job *model.Job, cfg *viper.Viper, workingdir st
 	for index, step := range job.Steps {
 		stepcfg := &ConvertStepParams{
 			Step:               &step,
-			Cfg:                cfg,
+			Cfg:                c.cfg,
 			Index:              index,
 			User:               job.Submitter,
 			UserID:             job.UserID,
@@ -251,7 +275,7 @@ func (j *JobCompose) InitFromJob(job *model.Job, cfg *viper.Viper, workingdir st
 			WorkingDirHostPath: workingVolumeHostPath,
 			AvailablePort:      availablePort,
 		}
-		if err = j.ConvertStep(stepcfg); err != nil {
+		if err = c.ConvertStep(stepcfg); err != nil {
 			return err
 		}
 	}
@@ -260,7 +284,7 @@ func (j *JobCompose) InitFromJob(job *model.Job, cfg *viper.Viper, workingdir st
 	excludesPath := path.Join(workingdir, UploadExcludesFilename)
 	excludesMount := path.Join(CONFIGDIR, UploadExcludesFilename)
 
-	j.Services["upload_outputs"] = &Service{
+	c.composition.Services["upload_outputs"] = &Service{
 		CapAdd:  []string{"IPC_LOCK"},
 		Image:   porklockImageName,
 		Command: job.FinalOutputArguments(excludesMount),
@@ -334,18 +358,16 @@ type ConvertStepParams struct {
 	AvailablePort      int
 }
 
-// ConvertStep will add the job step to the JobCompose services along with a
+// ConvertStep will add the job step to the JobComposition services along with a
 // proxy service.
-func (j *JobCompose) ConvertStep(c *ConvertStepParams) error {
+func (c *Composer) ConvertStep(s *ConvertStepParams) error {
 	var (
-		step               = c.Step
-		cfg                = c.Cfg
-		index              = c.Index
-		user               = c.User
-		userID             = c.UserID
-		invID              = c.InvID
-		workingDirHostPath = c.WorkingDirHostPath
-		availablePort      = c.AvailablePort
+		step               = s.Step
+		cfg                = s.Cfg
+		index              = s.Index
+		user               = s.User
+		workingDirHostPath = s.WorkingDirHostPath
+		availablePort      = s.AvailablePort
 	)
 
 	// Construct the name of the image
@@ -361,25 +383,24 @@ func (j *JobCompose) ConvertStep(c *ConvertStepParams) error {
 		imageName = step.Component.Container.Image.Name
 	}
 
-	ingressID := IngressID(invID, userID)
-	redirectURL, err := FrontendURL(invID, ingressID, step, cfg)
+	redirectURL, err := c.FrontendURL(step)
 	if err != nil {
 		return err
 	}
 
 	step.Environment["IPLANT_USER"] = user
-	step.Environment["IPLANT_EXECUTION_ID"] = invID
+	step.Environment["IPLANT_EXECUTION_ID"] = c.job.InvocationID
 	step.Environment["REDIRECT_URL"] = redirectURL
 
 	var containername string
 	if step.Component.Container.Name != "" {
 		containername = step.Component.Container.Name
 	} else {
-		containername = fmt.Sprintf("step_%d_%s", index, invID)
+		containername = fmt.Sprintf("step_%d_%s", index, c.job.InvocationID)
 	}
 
 	indexstr := strconv.Itoa(index)
-	j.Services[fmt.Sprintf("step_%d", index)] = &Service{
+	c.composition.Services[fmt.Sprintf("step_%d", index)] = &Service{
 		Image:      imageName,
 		Command:    step.Arguments(),
 		WorkingDir: step.Component.Container.WorkingDirectory(),
@@ -400,7 +421,7 @@ func (j *JobCompose) ConvertStep(c *ConvertStepParams) error {
 		Devices:       []string{},
 	}
 
-	svc := j.Services[fmt.Sprintf("step_%d", index)]
+	svc := c.composition.Services[fmt.Sprintf("step_%d", index)]
 	stepContainer := step.Component.Container
 
 	for _, cp := range step.Component.Container.Ports {
@@ -439,9 +460,9 @@ func (j *JobCompose) ConvertStep(c *ConvertStepParams) error {
 
 	// Handles volumes created by other containers.
 	for _, vf := range stepContainer.VolumesFrom {
-		containerName := fmt.Sprintf("%s-%s", vf.NamePrefix, invID)
+		containerName := fmt.Sprintf("%s-%s", vf.NamePrefix, c.job.InvocationID)
 		var foundService string
-		for svckey, svc := range j.Services { // svckey is the docker-compose service name.
+		for svckey, svc := range c.composition.Services { // svckey is the docker-compose service name.
 			if svc.ContainerName == containerName {
 				foundService = svckey
 			}
@@ -494,9 +515,9 @@ func (j *JobCompose) ConvertStep(c *ConvertStepParams) error {
 		backendURL = step.Component.Container.InteractiveApps.BackendURL
 	} else {
 		if containerPort != 0 {
-			backendURL = fmt.Sprintf("http://step_%d_%s:%d", index, invID, containerPort)
+			backendURL = fmt.Sprintf("http://step_%d_%s:%d", index, c.job.InvocationID, containerPort)
 		} else {
-			backendURL = fmt.Sprintf("http://step_%d_%s", index, invID)
+			backendURL = fmt.Sprintf("http://step_%d_%s", index, c.job.InvocationID)
 		}
 	}
 
@@ -505,14 +526,14 @@ func (j *JobCompose) ConvertStep(c *ConvertStepParams) error {
 		return err
 	}
 
-	frontendURL, err := FrontendURL(invID, ingressID, step, cfg)
+	frontendURL, err := c.FrontendURL(step)
 	if err != nil {
 		return err
 	}
 
 	// Add a service for the proxy container. Each step has a corresponding proxy.
-	proxyName := ProxyName(index, invID)
-	j.Services[ProxyServiceName(index)] = &Service{
+	proxyName := c.ProxyName(index)
+	c.composition.Services[ProxyServiceName(index)] = &Service{
 		Image: stepContainer.InteractiveApps.ProxyImage,
 		Command: []string{
 			"--backend-url", backendURL,
@@ -542,8 +563,8 @@ func (j *JobCompose) ConvertStep(c *ConvertStepParams) error {
 
 // ProxyName returns the name of the cas-proxy container based on the step index and the
 // job's invocationID.
-func ProxyName(index int, invocationID string) string {
-	return fmt.Sprintf("step_proxy_%d_%s", index, invocationID)
+func (c *Composer) ProxyName(index int) string {
+	return fmt.Sprintf("step_proxy_%d_%s", index, c.job.InvocationID)
 }
 
 // ProxyServiceName returns the docker-compose service name for the cas-proxy,

--- a/dcompose.go
+++ b/dcompose.go
@@ -89,7 +89,6 @@ func NewJobComposition(ld string, pathprefix string) (*JobComposition, error) {
 // Composer orchestrates the creation of the docker-compose file for a job.
 type Composer struct {
 	job             *model.Job
-	cfg             *viper.Viper
 	composition     *JobComposition
 	ingressID       string // This shouldn't be accessed directly. Use IngressID().
 	porklockImage   string
@@ -107,7 +106,6 @@ func NewComposer(job *model.Job, cfg *viper.Viper, logDriver, pathPrefix string)
 	}
 	return &Composer{
 		job:             job,
-		cfg:             cfg,
 		composition:     c,
 		porklockImage:   cfg.GetString(ConfigPorklockImageKey),
 		porklockTag:     cfg.GetString(ConfigPorklockTagKey),

--- a/dcompose_test.go
+++ b/dcompose_test.go
@@ -159,7 +159,7 @@ services:
     working_dir: /working_dir
 `
 
-	jc := &JobCompose{}
+	jc := &JobComposition{}
 	err := yaml.Unmarshal([]byte(expected), &jc)
 	if err != nil {
 		t.Error(err)
@@ -335,13 +335,13 @@ services:
 	}
 }
 
-func TestNew(t *testing.T) {
-	jc, err := New("", "")
+func TestNewJobComposition(t *testing.T) {
+	jc, err := NewJobComposition("", "")
 	if err != nil {
 		t.Error(err)
 	}
 	if jc == nil {
-		t.Error("New() returned nil")
+		t.Error("NewJobComposition() returned nil")
 	}
 	if jc.Version != "2.2" {
 		t.Errorf("version was %s", jc.Version)
@@ -349,12 +349,13 @@ func TestNew(t *testing.T) {
 }
 
 func TestConvertStep(t *testing.T) {
-	jc, err := New("", "")
+	cfg := viper.New()
+	cfg.Set("k8s.frontend.base", "http://cyverse.run/")
+
+	jc, err := NewComposer(testJob, cfg, "", "")
 	if err != nil {
 		t.Error(err)
 	}
-	cfg := viper.New()
-	cfg.Set("k8s.frontend.base", "http://cyverse.run/")
 
 	stepcfg := &ConvertStepParams{
 		Step:               &testJob.Steps[0],
@@ -367,14 +368,14 @@ func TestConvertStep(t *testing.T) {
 	}
 
 	jc.ConvertStep(stepcfg)
-	if len(jc.Services) != 2 {
-		t.Errorf("number of services was %d and not 1", len(jc.Services))
+	if len(jc.composition.Services) != 2 {
+		t.Errorf("number of services was %d and not 1", len(jc.composition.Services))
 	}
-	if _, ok := jc.Services["step_0"]; !ok {
+	if _, ok := jc.composition.Services["step_0"]; !ok {
 		t.Error("step_0 not found")
 	}
 
-	svc := jc.Services["step_0"]
+	svc := jc.composition.Services["step_0"]
 
 	if _, ok := svc.Environment["FOO"]; !ok {
 		t.Error("environment var FOO not found")

--- a/dcompose_test.go
+++ b/dcompose_test.go
@@ -359,7 +359,6 @@ func TestConvertStep(t *testing.T) {
 
 	stepcfg := &ConvertStepParams{
 		Step:               &testJob.Steps[0],
-		Cfg:                cfg,
 		Index:              0,
 		User:               testJob.Submitter,
 		InvID:              testJob.InvocationID,

--- a/main.go
+++ b/main.go
@@ -29,74 +29,76 @@ import (
 	"github.com/spf13/viper"
 )
 
-// ConfigDockerComposePathKey is the key for the config setting with the path
-// to the docker-compose executable.
-const ConfigDockerComposePathKey = "docker-compose.path"
+const (
+	// ConfigDockerComposePathKey is the key for the config setting with the path
+	// to the docker-compose executable.
+	ConfigDockerComposePathKey = "docker-compose.path"
 
-// ConfigDockerPathKey is the key for the config setting with the path to the
-// docker executable.
-const ConfigDockerPathKey = "docker.path"
+	// ConfigDockerPathKey is the key for the config setting with the path to the
+	// docker executable.
+	ConfigDockerPathKey = "docker.path"
 
-// ConfigDockerCFGKey is the key for the config setting with the path to the
-// docker client configuration file.
-const ConfigDockerCFGKey = "docker.cfg"
+	// ConfigDockerCFGKey is the key for the config setting with the path to the
+	// docker client configuration file.
+	ConfigDockerCFGKey = "docker.cfg"
 
-// ConfigProxyLowerKey is the key for the config setting with the lower bound
-// in the range from which an interactive app can be assigned a port.
-const ConfigProxyLowerKey = "proxy.lower"
+	// ConfigProxyLowerKey is the key for the config setting with the lower bound
+	// in the range from which an interactive app can be assigned a port.
+	ConfigProxyLowerKey = "proxy.lower"
 
-// ConfigProxyUpperKey is the key for the config setting with the upper bound
-// in the range from which an interactive app can be assigned a port.
-const ConfigProxyUpperKey = "proxy.upper"
+	// ConfigProxyUpperKey is the key for the config setting with the upper bound
+	// in the range from which an interactive app can be assigned a port.
+	ConfigProxyUpperKey = "proxy.upper"
 
-// ConfigSetfaclPathKey is the key for the config setting with the path to the
-// setfacl executable.
-const ConfigSetfaclPathKey = "setfacl.path"
+	// ConfigSetfaclPathKey is the key for the config setting with the path to the
+	// setfacl executable.
+	ConfigSetfaclPathKey = "setfacl.path"
 
-// ConfigMaxCPUCoresKey is the key for the config setting with the maximum
-// number of cores that a container can use.
-const ConfigMaxCPUCoresKey = "resources.max-cpu-cores"
+	// ConfigMaxCPUCoresKey is the key for the config setting with the maximum
+	// number of cores that a container can use.
+	ConfigMaxCPUCoresKey = "resources.max-cpu-cores"
 
-// ConfigMemoryLimitKey is the key for the config setting with the RAM limit
-// for each container.
-const ConfigMemoryLimitKey = "resources.memory-limit"
+	// ConfigMemoryLimitKey is the key for the config setting with the RAM limit
+	// for each container.
+	ConfigMemoryLimitKey = "resources.memory-limit"
 
-// ConfigFrontendBaseKey is the key for the frontend base URL configuration
-// setting.
-const ConfigFrontendBaseKey = "k8s.frontend.base"
+	// ConfigFrontendBaseKey is the key for the frontend base URL configuration
+	// setting.
+	ConfigFrontendBaseKey = "k8s.frontend.base"
 
-// ConfigAppExposerBaseKey is the key for the app-exposer base URL configuration
-// setting.
-const ConfigAppExposerBaseKey = "k8s.app-exposer.base"
+	// ConfigAppExposerBaseKey is the key for the app-exposer base URL configuration
+	// setting.
+	ConfigAppExposerBaseKey = "k8s.app-exposer.base"
 
-// ConfigHostHeaderKey is the key for the app-exposer Host header configuration
-// setting.
-const ConfigHostHeaderKey = "k8s.app-exposer.host-header"
+	// ConfigHostHeaderKey is the key for the app-exposer Host header configuration
+	// setting.
+	ConfigHostHeaderKey = "k8s.app-exposer.host-header"
 
-// ConfigVaultURLKey is the key for the Vault URL configuration setting.
-const ConfigVaultURLKey = "vault.url"
+	// ConfigVaultURLKey is the key for the Vault URL configuration setting.
+	ConfigVaultURLKey = "vault.url"
 
-// ConfigVaultTokenKey is the key for the Vault token configuration setting.
-const ConfigVaultTokenKey = "vault.token"
+	// ConfigVaultTokenKey is the key for the Vault token configuration setting.
+	ConfigVaultTokenKey = "vault.token"
 
-// ConfigPorklockImageKey is the key for the porklock image configuration
-// setting.
-const ConfigPorklockImageKey = "porklock.image"
+	// ConfigPorklockImageKey is the key for the porklock image configuration
+	// setting.
+	ConfigPorklockImageKey = "porklock.image"
 
-// ConfigPorklockTagKey is the key for the porklock image tag configuration
-// setting.
-const ConfigPorklockTagKey = "porklock.tag"
+	// ConfigPorklockTagKey is the key for the porklock image tag configuration
+	// setting.
+	ConfigPorklockTagKey = "porklock.tag"
 
-// ConfigAMQPURIKey is the key for the AMQP URI configuration setting.
-const ConfigAMQPURIKey = "amqp.uri"
+	// ConfigAMQPURIKey is the key for the AMQP URI configuration setting.
+	ConfigAMQPURIKey = "amqp.uri"
 
-// ConfigAMQPExchangeNameKey is the key for the AMQP Exchange Name configuration
-// setting.
-const ConfigAMQPExchangeNameKey = "amqp.exchange.name"
+	// ConfigAMQPExchangeNameKey is the key for the AMQP Exchange Name configuration
+	// setting.
+	ConfigAMQPExchangeNameKey = "amqp.exchange.name"
 
-// ConfigAMQPExchangeTypeKey is the key for the AMQP Exchange Type configuration
-// setting.
-const ConfigAMQPExchangeTypeKey = "amqp.exchange.type"
+	// ConfigAMQPExchangeTypeKey is the key for the AMQP Exchange Type configuration
+	// setting.
+	ConfigAMQPExchangeTypeKey = "amqp.exchange.type"
+)
 
 var (
 	job              *model.Job

--- a/main.go
+++ b/main.go
@@ -354,7 +354,7 @@ func main() {
 	}
 
 	// Generate the docker-compose file used to execute the job.
-	composer, err := New(*logdriver, *pathprefix)
+	composer, err := NewComposer(job, cfg, *logdriver, *pathprefix)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -364,7 +364,7 @@ func main() {
 
 	// Populates the data structure that will become the docker-compose file with
 	// information from the job definition.
-	composer.InitFromJob(job, cfg, wd, availablePort)
+	composer.InitFromJob(wd, availablePort)
 
 	// Write out the docker-compose file. This will get transferred back with the
 	// job outputs, which makes debugging stuff a lot easier.
@@ -374,7 +374,7 @@ func main() {
 	}
 	defer c.Close()
 
-	m, err := yaml.Marshal(composer)
+	m, err := yaml.Marshal(composer.composition)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -408,7 +408,7 @@ func main() {
 	)
 
 	// Actually execute all of the job steps.
-	exitCode := Run(ctx, client, job, cfg, exit, availablePort)
+	exitCode := Run(ctx, client, composer, exit, availablePort)
 
 	// Clean up the job file. Cleaning it out will prevent image-janitor and
 	// network-pruner from continuously trying to clean up after the job.

--- a/main.go
+++ b/main.go
@@ -408,7 +408,7 @@ func main() {
 	)
 
 	// Actually execute all of the job steps.
-	exitCode := Run(ctx, client, composer, exit, availablePort)
+	exitCode := Run(ctx, client, cfg, composer, exit, availablePort)
 
 	// Clean up the job file. Cleaning it out will prevent image-janitor and
 	// network-pruner from continuously trying to clean up after the job.

--- a/run.go
+++ b/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kr/pty"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"gopkg.in/cyverse-de/messaging.v4"
 	"gopkg.in/cyverse-de/model.v3"
 )
@@ -40,35 +41,49 @@ var logWriter = &logrusProxyWriter{
 
 // JobRunner provides the functionality needed to run jobs.
 type JobRunner struct {
-	client        JobUpdatePublisher
-	exit          chan messaging.StatusCode
-	composer      *Composer
-	status        messaging.StatusCode
-	logsDir       string
-	volumeDir     string
-	workingDir    string
-	projectName   string
-	tmpDir        string
-	networkName   string
-	availablePort int
+	client            JobUpdatePublisher
+	exit              chan messaging.StatusCode
+	composer          *Composer
+	status            messaging.StatusCode
+	logsDir           string
+	volumeDir         string
+	workingDir        string
+	projectName       string
+	tmpDir            string
+	networkName       string
+	availablePort     int
+	dockerPath        string
+	dockerComposePath string
+	vaultURL          string
+	vaultToken        string
+	setfaclPath       string
+	appExposerBaseURL string
+	appExposerHeader  string
 }
 
 // NewJobRunner creates a new JobRunner
-func NewJobRunner(client JobUpdatePublisher, c *Composer, exit chan messaging.StatusCode, availablePort int) (*JobRunner, error) {
+func NewJobRunner(client JobUpdatePublisher, cfg *viper.Viper, c *Composer, exit chan messaging.StatusCode, availablePort int) (*JobRunner, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
 	runner := &JobRunner{
-		client:        client,
-		exit:          exit,
-		composer:      c,
-		status:        messaging.Success,
-		workingDir:    cwd,
-		volumeDir:     path.Join(cwd, VOLUMEDIR),
-		logsDir:       path.Join(cwd, VOLUMEDIR, "logs"),
-		tmpDir:        path.Join(cwd, TMPDIR),
-		availablePort: availablePort,
+		client:            client,
+		exit:              exit,
+		composer:          c,
+		status:            messaging.Success,
+		workingDir:        cwd,
+		volumeDir:         path.Join(cwd, VOLUMEDIR),
+		logsDir:           path.Join(cwd, VOLUMEDIR, "logs"),
+		tmpDir:            path.Join(cwd, TMPDIR),
+		availablePort:     availablePort,
+		dockerPath:        cfg.GetString(ConfigDockerPathKey),
+		dockerComposePath: cfg.GetString(ConfigDockerComposePathKey),
+		vaultURL:          cfg.GetString(ConfigVaultURLKey),
+		vaultToken:        cfg.GetString(ConfigVaultTokenKey),
+		setfaclPath:       cfg.GetString(ConfigSetfaclPathKey),
+		appExposerBaseURL: cfg.GetString(ConfigAppExposerBaseKey),
+		appExposerHeader:  cfg.GetString(ConfigHostHeaderKey),
 	}
 	return runner, nil
 }
@@ -162,7 +177,7 @@ func (r *JobRunner) Init(ctx context.Context) error {
 // DockerLogin will run "docker login" with credentials sent with the job.
 func (r *JobRunner) DockerLogin() error {
 	var err error
-	dockerBin := r.composer.cfg.GetString(ConfigDockerPathKey)
+
 	// Login so that images can be pulled.
 	var authinfo *authInfo
 	for _, img := range r.composer.job.ContainerImages() {
@@ -172,7 +187,7 @@ func (r *JobRunner) DockerLogin() error {
 				return err
 			}
 			authCommand := exec.Command(
-				dockerBin,
+				r.dockerPath,
 				"login",
 				"--username",
 				authinfo.Username,
@@ -204,10 +219,9 @@ type JobUpdatePublisher interface {
 
 func (r *JobRunner) execDockerCompose(ctx context.Context, svcname string, env []string, stdout, stderr io.Writer) error {
 	var err error
-	composePath := r.composer.cfg.GetString(ConfigDockerComposePathKey)
 	cmd := exec.CommandContext(
 		ctx,
-		composePath,
+		r.dockerComposePath,
 		"-p",
 		r.projectName,
 		"-f",
@@ -254,8 +268,8 @@ func (r *JobRunner) downloadInputs(ctx context.Context) (messaging.StatusCode, e
 	var exitCode int64
 
 	env := os.Environ()
-	env = append(env, fmt.Sprintf("VAULT_ADDR=%s", r.composer.cfg.GetString(ConfigVaultURLKey)))
-	env = append(env, fmt.Sprintf("VAULT_TOKEN=%s", r.composer.cfg.GetString(ConfigVaultTokenKey)))
+	env = append(env, fmt.Sprintf("VAULT_ADDR=%s", r.vaultURL))
+	env = append(env, fmt.Sprintf("VAULT_TOKEN=%s", r.vaultToken))
 
 	for index, input := range r.composer.job.Inputs() {
 		running(r.client, r.composer.job, fmt.Sprintf("Downloading %s", input.IRODSPath()))
@@ -289,8 +303,7 @@ func (r *JobRunner) downloadInputs(ctx context.Context) (messaging.StatusCode, e
 
 // ImageUser returns the UID of the image's default user, or 0 if it's not set.
 func (r *JobRunner) ImageUser(ctx context.Context, image string) (int, error) {
-	dockerPath := r.composer.cfg.GetString(ConfigDockerPathKey)
-	out, err := exec.CommandContext(ctx, dockerPath, "image", "inspect", "-f", "{{.Config.User}}", image).Output()
+	out, err := exec.CommandContext(ctx, r.dockerPath, "image", "inspect", "-f", "{{.Config.User}}", image).Output()
 	if err != nil {
 		return -1, err
 	}
@@ -306,8 +319,7 @@ func (r *JobRunner) ImageUser(ctx context.Context, image string) (int, error) {
 // rwx perms recursively. It is not a default ACL.
 func (r *JobRunner) AddWorkingVolumeACL(ctx context.Context, uid int) error {
 	log.Printf("adding rwx acl on %s recursively for uid %d", r.volumeDir, uid)
-	setfaclPath := r.composer.cfg.GetString(ConfigSetfaclPathKey)
-	cmd := exec.CommandContext(ctx, setfaclPath, "-R", "-m", fmt.Sprintf("d:u:%d:rwx", uid), r.volumeDir)
+	cmd := exec.CommandContext(ctx, r.setfaclPath, "-R", "-m", fmt.Sprintf("d:u:%d:rwx", uid), r.volumeDir)
 	cmd.Env = os.Environ()
 	cmd.Stdout = logWriter
 	cmd.Stderr = logWriter
@@ -318,8 +330,7 @@ func (r *JobRunner) AddWorkingVolumeACL(ctx context.Context, uid int) error {
 // directory that gets mounted into each container that runs as part of the job.
 func (r *JobRunner) RemoveWorkingVolumeACL(ctx context.Context, uid int) error {
 	log.Printf("removing rwx acl on %s recursively for uid %d", r.volumeDir, uid)
-	setfaclPath := r.composer.cfg.GetString(ConfigSetfaclPathKey)
-	cmd := exec.CommandContext(ctx, setfaclPath, "-R", "-x", fmt.Sprintf("u:%d", uid), r.volumeDir)
+	cmd := exec.CommandContext(ctx, r.setfaclPath, "-R", "-x", fmt.Sprintf("u:%d", uid), r.volumeDir)
 	cmd.Env = os.Environ()
 	cmd.Stdout = logWriter
 	cmd.Stderr = logWriter
@@ -428,8 +439,6 @@ func (r *JobRunner) runAllSteps(parent context.Context) (messaging.StatusCode, e
 			}
 		}()
 
-		exposerURL := r.composer.cfg.GetString(ConfigAppExposerBaseKey)
-		exposerHost := r.composer.cfg.GetString(ConfigHostHeaderKey)
 		ingressID := r.composer.IngressID()
 
 		log.Printf("creating K8s endpoint %s\n", ingressID)
@@ -439,9 +448,9 @@ func (r *JobRunner) runAllSteps(parent context.Context) (messaging.StatusCode, e
 			Name: ingressID,
 			Port: r.availablePort,
 		}
-		if err = CreateK8SEndpoint(exposerURL, exposerHost, eptcfg); err != nil {
+		if err = CreateK8SEndpoint(r.appExposerBaseURL, r.appExposerHeader, eptcfg); err != nil {
 			running(r.client, r.composer.job, fmt.Sprintf("Error creating K8s Endpoint: %s", err.Error()))
-			DeleteK8SEndpoint(exposerURL, exposerHost, ingressID)
+			DeleteK8SEndpoint(r.appExposerBaseURL, r.appExposerHeader, ingressID)
 			return messaging.StatusStepFailed, err
 		}
 		log.Printf("done creating K8s endpoint %s\n", ingressID)
@@ -452,10 +461,10 @@ func (r *JobRunner) runAllSteps(parent context.Context) (messaging.StatusCode, e
 			Name:       ingressID,
 			ListenPort: 80,
 		}
-		if err = CreateK8SService(exposerURL, exposerHost, svccfg); err != nil {
+		if err = CreateK8SService(r.appExposerBaseURL, r.appExposerHeader, svccfg); err != nil {
 			running(r.client, r.composer.job, fmt.Sprintf("Error creating K8s Service: %s", err.Error()))
-			DeleteK8SService(exposerURL, exposerHost, ingressID)
-			DeleteK8SEndpoint(exposerURL, exposerHost, ingressID)
+			DeleteK8SService(r.appExposerBaseURL, r.appExposerHeader, ingressID)
+			DeleteK8SEndpoint(r.appExposerBaseURL, r.appExposerHeader, ingressID)
 			return messaging.StatusStepFailed, err
 		}
 		log.Printf("done creating K8s service %s\n", ingressID)
@@ -466,11 +475,11 @@ func (r *JobRunner) runAllSteps(parent context.Context) (messaging.StatusCode, e
 			Port:    80,
 			Name:    ingressID,
 		}
-		if err = CreateK8SIngress(exposerURL, exposerHost, ingcfg); err != nil {
+		if err = CreateK8SIngress(r.appExposerBaseURL, r.appExposerHeader, ingcfg); err != nil {
 			running(r.client, r.composer.job, fmt.Sprintf("Error creating K8s Ingress: %s", err.Error()))
-			DeleteK8SIngress(exposerURL, exposerHost, ingressID)
-			DeleteK8SService(exposerURL, exposerHost, ingressID)
-			DeleteK8SEndpoint(exposerURL, exposerHost, ingressID)
+			DeleteK8SIngress(r.appExposerBaseURL, r.appExposerHeader, ingressID)
+			DeleteK8SService(r.appExposerBaseURL, r.appExposerHeader, ingressID)
+			DeleteK8SEndpoint(r.appExposerBaseURL, r.appExposerHeader, ingressID)
 			return messaging.StatusStepFailed, err
 		}
 		log.Printf("done creating K8s ingress %s\n", ingressID)
@@ -503,19 +512,19 @@ func (r *JobRunner) runAllSteps(parent context.Context) (messaging.StatusCode, e
 		// right thing to do, but it's easy to fix if it becomes a problem. Just
 		// return messaging.StatusStepFailed and the error.
 		log.Printf("deleting K8s endpoint %s\n", ingressID)
-		if err = DeleteK8SEndpoint(exposerURL, exposerHost, ingressID); err != nil {
+		if err = DeleteK8SEndpoint(r.appExposerBaseURL, r.appExposerHeader, ingressID); err != nil {
 			running(r.client, r.composer.job, fmt.Sprintf("Error deleting K8s endpoint: %s", err.Error()))
 		}
 		log.Printf("done deleting K8s endpoint %s\n", ingressID)
 
 		log.Printf("deleting K8s service %s\n", ingressID)
-		if err = DeleteK8SService(exposerURL, exposerHost, ingressID); err != nil {
+		if err = DeleteK8SService(r.appExposerBaseURL, r.appExposerHeader, ingressID); err != nil {
 			running(r.client, r.composer.job, fmt.Sprintf("Error deleting K8s service: %s", err.Error()))
 		}
 		log.Printf("done deleting K8s service %s\n", ingressID)
 
 		log.Printf("deleting K8s ingress %s\n", ingressID)
-		if err = DeleteK8SIngress(exposerURL, exposerHost, ingressID); err != nil {
+		if err = DeleteK8SIngress(r.appExposerBaseURL, r.appExposerHeader, ingressID); err != nil {
 			running(r.client, r.composer.job, fmt.Sprintf("Error deleting K8s ingress: %s", err.Error()))
 		}
 		log.Printf("done deleting K8s ingress %s\n", ingressID)
@@ -544,8 +553,8 @@ func (r *JobRunner) uploadOutputs() (messaging.StatusCode, error) {
 	defer stderr.Close()
 
 	env := []string{
-		fmt.Sprintf("VAULT_ADDR=%s", r.composer.cfg.GetString(ConfigVaultURLKey)),
-		fmt.Sprintf("VAULT_TOKEN=%s", r.composer.cfg.GetString(ConfigVaultTokenKey)),
+		fmt.Sprintf("VAULT_ADDR=%s", r.vaultURL),
+		fmt.Sprintf("VAULT_TOKEN=%s", r.vaultToken),
 	}
 
 	// We're using the background context so that this stuff will run even when
@@ -645,14 +654,14 @@ func (r *JobRunner) dockerComposePull(ctx context.Context, composePath string) e
 }
 
 // Run executes the job, and returns the exit code on the exit channel.
-func Run(ctx context.Context, client JobUpdatePublisher, c *Composer, exit chan messaging.StatusCode, availablePort int) messaging.StatusCode {
+func Run(ctx context.Context, client JobUpdatePublisher, cfg *viper.Viper, c *Composer, exit chan messaging.StatusCode, availablePort int) messaging.StatusCode {
 	host, err := os.Hostname()
 	if err != nil {
 		log.Error(err)
 		host = "UNKNOWN"
 	}
 
-	runner, err := NewJobRunner(client, c, exit, availablePort)
+	runner, err := NewJobRunner(client, cfg, c, exit, availablePort)
 	if err != nil {
 		log.Error(err)
 	}
@@ -664,8 +673,6 @@ func Run(ctx context.Context, client JobUpdatePublisher, c *Composer, exit chan 
 
 	runner.projectName = strings.Replace(runner.composer.job.InvocationID, "-", "", -1)
 	runner.networkName = fmt.Sprintf("%s_default", runner.projectName)
-	dockerPath := runner.composer.cfg.GetString(ConfigDockerPathKey)
-	composePath := runner.composer.cfg.GetString(ConfigDockerComposePathKey)
 
 	// let everyone know the job is running
 	running(runner.client, runner.composer.job, fmt.Sprintf("Job %s is running on host %s", runner.composer.job.InvocationID, host))
@@ -674,11 +681,11 @@ func Run(ctx context.Context, client JobUpdatePublisher, c *Composer, exit chan 
 		log.Error(err)
 	}
 
-	if err = runner.createNetwork(ctx, dockerPath, runner.networkName); err != nil {
+	if err = runner.createNetwork(ctx, runner.dockerPath, runner.networkName); err != nil {
 		log.Error(err) // don't need to fail, since docker-compose is *supposed* to create the network
 	}
 
-	if err = runner.dockerComposePull(ctx, composePath); err != nil {
+	if err = runner.dockerComposePull(ctx, runner.dockerComposePath); err != nil {
 		log.Error(err)
 		runner.status = messaging.StatusDockerPullFailed
 	}
@@ -733,14 +740,14 @@ func Run(ctx context.Context, client JobUpdatePublisher, c *Composer, exit chan 
 	}
 
 	// Clean up, you filthy animal
-	downCommand := exec.Command(composePath, "-p", runner.projectName, "-f", "docker-compose.yml", "down", "-v")
+	downCommand := exec.Command(runner.dockerComposePath, "-p", runner.projectName, "-f", "docker-compose.yml", "down", "-v")
 	downCommand.Stderr = log.Writer()
 	downCommand.Stdout = log.Writer()
 	if err = downCommand.Run(); err != nil {
 		log.Errorf("%+v\n", err)
 	}
 
-	netCmd := exec.Command(dockerPath, "network", "rm", fmt.Sprintf("%s_default", runner.projectName))
+	netCmd := exec.Command(runner.dockerPath, "network", "rm", fmt.Sprintf("%s_default", runner.projectName))
 	netCmd.Stderr = log.Writer()
 	netCmd.Stdout = log.Writer()
 	if err = netCmd.Run(); err != nil {


### PR DESCRIPTION
Contains a pretty hefty reorganization of the code to prevent calls to Viper from being scattered throughout the code. Pulled the dcompose and fs packages into main in the hopes that it might simplify the dependency management a bit.