### PR TITLE
CORE-9219 Set 777 perms on job's temp dir.

### DIFF
--- a/dcompose.go
+++ b/dcompose.go
@@ -483,9 +483,7 @@ func (c *Composer) ConvertStep(s *ConvertStepParams) error {
 	svc.Volumes = append(svc.Volumes, strings.Join([]string{workingDirHostPath, stepContainer.WorkingDirectory(), "rw"}, ":"))
 
 	// The TMPDIR needs to be mounted as a volume
-	if !step.Component.Container.SkipTmpMount {
-		svc.Volumes = append(svc.Volumes, fmt.Sprintf("./%s:/tmp:rw", TMPDIR))
-	}
+	svc.Volumes = append(svc.Volumes, fmt.Sprintf("./%s:/tmp:rw", TMPDIR))
 
 	for _, v := range stepContainer.Volumes {
 		var rw string

--- a/run.go
+++ b/run.go
@@ -131,6 +131,13 @@ func (r *JobRunner) Init(ctx context.Context) error {
 		log.Error(err)
 	}
 
+	// Set world-write perms on tmpDir, so non-root users can create temp outputs.
+	err = os.Chmod(r.tmpDir, 0777)
+	if err != nil {
+		// Log error and continue.
+		log.Error(err)
+	}
+
 	// Copy docker-compose file to the log dir for debugging purposes.
 	err = CopyFile(FS, "docker-compose.yml", path.Join(r.logsDir, "docker-compose.yml"))
 	if err != nil {


### PR DESCRIPTION
This PR is a port of the cyverse-de/road-runner#15 fix, and also removes the check for `Container.SkipTmpMount` (which should no longer be needed with this fix).

This is a fairly minor change, so it's not critical for the next release, but it will allow 1 less setting to be added for cyverse-de/ui#354.